### PR TITLE
Fix QR code generation on business card

### DIFF
--- a/src/pages/business-card.astro
+++ b/src/pages/business-card.astro
@@ -13,7 +13,7 @@
 		<link rel="stylesheet" href="https://unpkg.com/xp.css" id="winxp-css" disabled />
 		
 		<!-- QR Code library -->
-		<script src="https://cdn.jsdelivr.net/npm/qrcode/build/qrcode.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 		
 		<style>
 			@page {
@@ -147,7 +147,11 @@
 				text-align: center;
 			}
 			
-			.qr-container canvas {
+			#qrcode {
+				display: inline-block;
+			}
+			
+			#qrcode img {
 				max-width: 120px;
 				max-height: 120px;
 			}
@@ -266,7 +270,7 @@
 				<div class="window-body">
 					<div class="card-back">
 						<div class="qr-container">
-							<canvas id="qrcode"></canvas>
+							<div id="qrcode"></div>
 							<div class="qr-label">evangelista.moe</div>
 						</div>
 					</div>
@@ -276,16 +280,18 @@
 		
 		<script>
 			// Generate QR code
-			window.addEventListener('load', () => {
-				const canvas = document.getElementById('qrcode');
-				QRCode.toCanvas(canvas, 'https://evangelista.moe', {
-					width: 120,
-					margin: 1,
-					color: {
-						dark: '#000000',
-						light: '#FFFFFF'
-					}
-				});
+			window.addEventListener('DOMContentLoaded', () => {
+				const qrElement = document.getElementById('qrcode');
+				if (qrElement && typeof QRCode !== 'undefined') {
+					new QRCode(qrElement, {
+						text: 'https://evangelista.moe',
+						width: 120,
+						height: 120,
+						colorDark: '#000000',
+						colorLight: '#FFFFFF',
+						correctLevel: QRCode.CorrectLevel.H
+					});
+				}
 			});
 			
 			// Theme switcher for preview


### PR DESCRIPTION
## Summary
Fixed the QR code that wasn't displaying on the business card back side

## Changes
- Switched from qrcode npm package to qrcode.js CDN library
- Changed from canvas element to div element for QR code rendering  
- Updated initialization to use DOMContentLoaded event
- Added proper error checking for QR code library

## Test Plan
- [x] Verified QR code displays on business card back
- [x] Tested QR code scans correctly to evangelista.moe
- [x] Confirmed both Win98 and WinXP themes work

🤖 Generated with [Claude Code](https://claude.ai/code)