### PR TITLE
Remove ADHD references and update messaging

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -361,17 +361,17 @@
 											</div>
 										</div>
 										<div class="skill-card">
-											<img src="https://win98icons.alexmeub.com/icons/png/joystick-2.png" alt="Turbo" class="skill-icon" />
+											<img src="https://win98icons.alexmeub.com/icons/png/html-3.png" alt="Web" class="skill-icon" />
 											<div class="skill-content">
-												<div class="skill-title">60x Performance</div>
-												<div class="skill-desc">Speed optimization</div>
+												<div class="skill-title">Modern Web Dev</div>
+												<div class="skill-desc">React, TypeScript, Next.js</div>
 											</div>
 										</div>
 										<div class="skill-card">
-											<img src="https://win98icons.alexmeub.com/icons/png/settings_gear-0.png" alt="Settings" class="skill-icon" />
+											<img src="https://win98icons.alexmeub.com/icons/png/joystick-2.png" alt="Rapid" class="skill-icon" />
 											<div class="skill-content">
-												<div class="skill-title">ADHD Hyperfocus</div>
-												<div class="skill-desc">Superpower mode</div>
+												<div class="skill-title">Rapid Prototyping</div>
+												<div class="skill-desc">Hours, not weeks</div>
 											</div>
 										</div>
 									</div>
@@ -410,7 +410,7 @@
 											<ul>
 												<li>Advanced prompt engineering</li>
 												<li>Custom Claude agent architectures</li>
-												<li>60% faster development</li>
+												<li>Prototypes in hours</li>
 											</ul>
 										</details>
 									</li>
@@ -488,7 +488,7 @@
 								</div>
 								<div class="field-row">
 									<label>Superpower:</label>
-									<input type="text" value="ADHD hyperfocus" readonly>
+									<input type="text" value="Rapid prototyping" readonly>
 								</div>
 								<div class="field-row">
 									<label>Coffee Required:</label>
@@ -497,7 +497,7 @@
 								<div class="field-row">
 									<label>Optimization Level:</label>
 									<select disabled>
-										<option selected>60x or bust</option>
+										<option selected>Hours not weeks</option>
 									</select>
 								</div>
 							</article>
@@ -554,12 +554,12 @@
 										<td>15+ years</td>
 									</tr>
 									<tr>
-										<td>ADHD:</td>
-										<td>Enabled</td>
+										<td>Prototyping:</td>
+										<td>Rapid</td>
 									</tr>
 									<tr>
-										<td>Best optimization:</td>
-										<td>60x</td>
+										<td>UX Focus:</td>
+										<td>Human-centric</td>
 									</tr>
 								</table>
 							</div>
@@ -594,7 +594,7 @@
 						<!-- Status bar -->
 						<div class="status-bar">
 							<p class="status-bar-field">Ready</p>
-							<p class="status-bar-field">ADHD: Enabled</p>
+							<p class="status-bar-field">Mode: Create</p>
 							<p class="status-bar-field"><span id="clock">12:00 PM</span></p>
 						</div>
 					</div>


### PR DESCRIPTION
Updates portfolio messaging to focus on rapid prototyping instead of ADHD references:

- Replace 'ADHD hyperfocus' with 'Rapid prototyping' throughout
- Update Core Skills grid with 'Modern Web Dev' and 'Rapid Prototyping'
- Change status bar from 'ADHD: Enabled' to 'Mode: Create'
- Update System tab optimization level to 'Hours not weeks'
- Focus on truthful messaging about rapid prototyping capabilities